### PR TITLE
the first ip in  x-ip-chan is always the correct client IP, 

### DIFF
--- a/headers-server.js
+++ b/headers-server.js
@@ -88,9 +88,7 @@ headers.ready = function(self) {
 headers.getClientIP = function(self, proxyCount) {
   checkSelf(self, 'getClientIP');
   var chain = this.get(self, 'x-ip-chain').split(',');
-  if (typeof(proxyCount) == 'undefined')
-    proxyCount = this.proxyCount;
-  return chain[proxyCount];
+  return chain[0];
 }
 
 /*
@@ -127,9 +125,7 @@ headers.methodGet = function(self, header) {
 headers.methodClientIP = function(self, proxyCount) {
   checkSelf(self, 'methodClientIP');
   var chain = this.methodGet(self, 'x-ip-chain');
-  if (typeof(proxyCount) == 'undefined')
-    proxyCount = this.proxyCount;
-  return chain[proxyCount];
+  return chain[0];
 }
 
 /*


### PR DESCRIPTION
this is just a demonstration pull req related to https://github.com/gadicohen/meteor-headers/issues/15 and is not intended for merge.
if you you agree that x-ip-chan's first value is always the correct client's IP address with meteor 0.7.1.2, a refactor will be needed.

Right now I,m using dev4side/meteor-header repo in my project smart.json and I'm receiving the correct client IP.

let me know what do you think
