### PR TITLE
fix cordova issue with headersHelper.js

### DIFF
--- a/lib/headers-client.js
+++ b/lib/headers-client.js
@@ -64,10 +64,11 @@ if (__headers__) {
  	* why this is necessary).  Called with our unique token, the retrieved
  	* code runs headers.store() above with the results
 	*/
+	var baseUrl = Meteor.absoluteUrl('/headersHelper.js?token=' + headers.token);
 	(function(d, t) {
 	    var g = d.createElement(t),
 	        s = d.getElementsByTagName(t)[0];
-	    g.src = '/headersHelper.js?token=' + headers.token;
+	    g.src = baseUrl;
 	    s.parentNode.insertBefore(g, s);
 	}(document, 'script'));
 }


### PR DESCRIPTION
on android cordova the following error is shown
Uncaught SyntaxError: Unexpected token <

this is probably because on android the app is always on localhost.
hopefully using Meteor.absoluteUrl will fix this issue and use the ROOT_URL as defined in compilation